### PR TITLE
chore: align packaging metadata with published name, drop Python 3.7 (2.2.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ venv
 .envrc
 __pycache__
 *.egg-info
+build
 dist
 docs/_build
 .env

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,6 +1,15 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
 python:
   install:
     - method: pip
       path: .
+    - requirements: dev-requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 ## Changelog
 
+### Release 2.1.1
+
+Packaging and documentation only. No functional changes to the library.
+
+#### Documentation
+- align README, Sphinx docs and install instructions with the published distribution name `uptime-kuma-api2` (the import package remains `uptime_kuma_api`)
+- clarify that PyPI `uptime-kuma-api` (upstream) and `uptime-kuma-api-v2` (unrelated maintainer) are not this fork
+- correct the documented test command: only the six v2 test files run without a live server, and warn that the inherited integration tests wipe all data on the target instance
+- replace the Read the Docs link that pointed at the upstream project with local Sphinx build instructions
+
+#### Packaging
+- add `project_urls` (Source, Changelog, Issues) for the PyPI sidebar
+- add Python 3.12 and 3.13 classifiers to match the versions CI tests
+- add a valid `build` section to `.readthedocs.yaml` so Read the Docs builds can succeed
+- bump Sphinx to 7.4.7; the previous 5.3.0 pin fails on Python 3.12+ because `imghdr` was removed
+- ignore the `build/` directory
+
+#### Bugfixes
+- fix `SyntaxWarning: invalid escape sequence '\*'` raised on import under Python 3.12+ (`set_settings` docstring)
+- fix Sphinx warnings: malformed literal block in the `UptimeKumaApi` docstring, missing `_static` path, and `install` missing from the toctree
+
 ### Release 2.1.0
 
 #### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## Changelog
 
-### Release 2.1.1
+### Release 2.2.0
 
-Packaging and documentation only. No functional changes to the library.
+No functional changes to the library. Packaging, documentation, and supported Python versions only.
+
+#### BREAKING CHANGES
+- Python 3.8+ required. Support for Python 3.7 is dropped; it has been end-of-life since June 2023 and was never covered by CI. Installs on 3.7 will resolve to 2.1.0 or earlier.
 
 #### Documentation
 - align README, Sphinx docs and install instructions with the published distribution name `uptime-kuma-api2` (the import package remains `uptime_kuma_api`)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ uptime-kuma-api2 is a Python wrapper for the [Uptime Kuma](https://github.com/lo
 
 This package was originally developed to configure Uptime Kuma with Ansible. The original Ansible collection can be found at https://github.com/lucasheld/ansible-uptime-kuma.
 
-Python version 3.7+ is required.
+Python version 3.8+ is required. Tested on 3.8 through 3.13.
 
 Supported Uptime Kuma versions:
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-# uptime-kuma-api-v2
+# uptime-kuma-api2
 
 A wrapper for the Uptime Kuma Socket.IO API — with full v2 support
 ---
 
 > **Fork notice:** This is an actively maintained fork of [lucasheld/uptime-kuma-api](https://github.com/lucasheld/uptime-kuma-api), which appears to be unmaintained (last release: 2023, open PRs unanswered). This fork adds full Uptime Kuma v2.x support while maintaining backward compatibility with v1.x. Original work by [Lucas Held](https://github.com/lucasheld) — thank you for building the foundation.
 
-uptime-kuma-api-v2 is a Python wrapper for the [Uptime Kuma](https://github.com/louislam/uptime-kuma) Socket.IO API.
+> **Naming:** the PyPI distribution is `uptime-kuma-api2`, while the import package remains `uptime_kuma_api` so existing code works unchanged. The unrelated PyPI projects `uptime-kuma-api` (upstream) and `uptime-kuma-api-v2` (different maintainer) are not this fork.
+
+uptime-kuma-api2 is a Python wrapper for the [Uptime Kuma](https://github.com/louislam/uptime-kuma) Socket.IO API.
 
 This package was originally developed to configure Uptime Kuma with Ansible. The original Ansible collection can be found at https://github.com/lucasheld/ansible-uptime-kuma.
 
@@ -13,11 +15,13 @@ Python version 3.7+ is required.
 
 Supported Uptime Kuma versions:
 
-| Uptime Kuma     | uptime-kuma-api |
-|-----------------|-----------------|
-| 2.0.0 - 2.4.0   | 2.0.0 - 2.1.0   |
-| 1.21.3 - 1.23.2 | 1.0.0 - 1.2.1   |
-| 1.17.0 - 1.21.2 | 0.1.0 - 0.13.0  |
+| Uptime Kuma     | uptime-kuma-api2 |
+|-----------------|------------------|
+| 2.0.0 - 2.4.0   | 2.0.0 - 2.1.0    |
+| 1.21.3 - 1.23.2 | 1.0.0 - 1.2.1    |
+| 1.17.0 - 1.21.2 | 0.1.0 - 0.13.0   |
+
+Releases 1.2.1 and earlier were published under the upstream `uptime-kuma-api` name; 2.0.0 onward are published as `uptime-kuma-api2`.
 
 Installation
 ---
@@ -31,7 +35,14 @@ pip install uptime-kuma-api2
 
 Documentation
 ---
-The API Reference is available on [Read the Docs](https://uptime-kuma-api.readthedocs.io).
+API documentation lives in the [`docs/`](docs/) directory of this repository and can be built locally with Sphinx:
+
+```
+pip install -r dev-requirements.txt
+cd docs && make html
+```
+
+Note: [uptime-kuma-api.readthedocs.io](https://uptime-kuma-api.readthedocs.io) is the upstream project's site and does not document this fork's v2 features.
 
 Example
 ---
@@ -108,12 +119,14 @@ New in v2.1.0
 
 Testing
 ---
-Unit tests cover all v2 features and can be run without a live server:
+The v2 unit tests need no live server. These are the tests CI runs:
 
 ```
 pip install pytest
-pytest tests/ -v
+pytest tests/test_monitor_types_v2.py tests/test_monitor_params_v2.py tests/test_status_page_v2.py tests/test_notification_v2.py tests/test_logger.py tests/test_monitor_builder.py -v
 ```
+
+The remaining test files are integration tests inherited from upstream. They expect a live Uptime Kuma instance at `http://127.0.0.1:3001` and will **delete all monitors, notifications, proxies, tags, status pages, docker hosts, maintenances and API keys** on that instance, so never point them at a production server.
 
 Test files:
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-Sphinx==5.3.0
-pyotp==2.8.0
-Jinja2==3.1.2
-BeautifulSoup4==4.12.2
+Sphinx==7.4.7
+pyotp==2.9.0
+Jinja2==3.1.4
+BeautifulSoup4==4.12.3

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,8 +12,8 @@ import uptime_kuma_api
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'uptime-kuma-api-v2'
-copyright = '2025, Paolo Barone'
+project = 'uptime-kuma-api2'
+copyright = '2025-2026, Paolo Barone'
 author = 'Paolo Barone'
 
 version = uptime_kuma_api.__version__
@@ -39,7 +39,6 @@ add_module_names = False
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = 'alabaster'
-html_static_path = ['_static']
 
 html_theme_options = {
     "show_powered_by": False,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,10 @@
-.. uptime-kuma-api documentation master file, created by
+.. uptime-kuma-api2 documentation master file, created by
    sphinx-quickstart on Thu Dec 15 11:58:11 2022.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-uptime-kuma-api
-===============
+uptime-kuma-api2
+================
 
 Release v\ |version|. (:ref:`Installation <install>`)
 
@@ -29,4 +29,5 @@ this part of the documentation is for you.
 .. toctree::
    :maxdepth: 3
 
+   install
    api

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -3,6 +3,11 @@
 Installation
 ------------
 
-To install uptime-kuma-api, run this command in your terminal::
+To install uptime-kuma-api2, run this command in your terminal::
 
-    $ pip install uptime-kuma-api
+    $ pip install uptime-kuma-api2
+
+The distribution is named ``uptime-kuma-api2``, but the import package is
+``uptime_kuma_api``::
+
+    from uptime_kuma_api import UptimeKumaApi

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     author_email="pbarone@users.noreply.github.com",
     license=info["__license__"],
     packages=["uptime_kuma_api"],
-    python_requires=">=3.7, <4",
+    python_requires=">=3.8, <4",
     install_requires=[
         "python-socketio[client]>=5.0.0",
         "packaging"
@@ -48,7 +48,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,11 @@ setup(
     long_description=readme,
     long_description_content_type="text/markdown",
     url="https://github.com/pbarone/uptime-kuma-api-v2",
+    project_urls={
+        "Source": "https://github.com/pbarone/uptime-kuma-api-v2",
+        "Changelog": "https://github.com/pbarone/uptime-kuma-api-v2/blob/main/CHANGELOG.md",
+        "Issues": "https://github.com/pbarone/uptime-kuma-api-v2/issues",
+    },
     author=info["__author__"],
     author_email="pbarone@users.noreply.github.com",
     license=info["__license__"],
@@ -48,6 +53,8 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Software Development :: Libraries"

--- a/uptime_kuma_api/__version__.py
+++ b/uptime_kuma_api/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "uptime_kuma_api"
-__version__ = "2.1.1"
+__version__ = "2.2.0"
 __author__ = "Paolo Barone"
 __license__ = "MIT"
 __copyright__ = "Copyright 2025-2026 Paolo Barone"

--- a/uptime_kuma_api/__version__.py
+++ b/uptime_kuma_api/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "uptime_kuma_api"
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 __author__ = "Paolo Barone"
 __license__ = "MIT"
-__copyright__ = "Copyright 2025 Paolo Barone"
+__copyright__ = "Copyright 2025-2026 Paolo Barone"

--- a/uptime_kuma_api/api.py
+++ b/uptime_kuma_api/api.py
@@ -407,7 +407,7 @@ def _check_arguments_tag(kwargs) -> None:
 class UptimeKumaApi(object):
     """This class is used to communicate with Uptime Kuma.
 
-    Example::
+    Example:
 
     Import UptimeKumaApi from the library and specify the Uptime Kuma server url (e.g. 'http://127.0.0.1:3001'), username and password to initialize the connection.
 
@@ -2957,7 +2957,7 @@ class UptimeKumaApi(object):
             # reverse proxy
             trustProxy: bool = False
     ) -> dict:
-        """
+        r"""
         Set settings.
 
         :param str, optional password: Password, defaults to None


### PR DESCRIPTION
Packaging, documentation, and supported-Python cleanup ahead of the 2.2.0 release. No functional changes to the library.

## Why

The published PyPI distribution is `uptime-kuma-api2`, but the docs still called the project `uptime-kuma-api-v2` - which is a different maintainer's package on PyPI. Anyone following the README would install the wrong thing. Auditing that turned up three genuine breakages as well.

## Changes

**Naming alignment**
- README, Sphinx docs, and install instructions now use `uptime-kuma-api2`; noted that the import package stays `uptime_kuma_api` so existing code is unaffected
- Explicit note that PyPI `uptime-kuma-api` (upstream) and `uptime-kuma-api-v2` (unrelated maintainer) are not this fork

**Bugfixes**
- `SyntaxWarning: invalid escape sequence '\*'` was raised on every import under Python 3.12+ from the `set_settings` docstring; now a raw string
- `dev-requirements.txt` pinned Sphinx 5.3.0, which cannot run on Python 3.13 at all (`imghdr` removed from stdlib) - docs builds were broken; bumped to 7.4.7
- `.readthedocs.yaml` had no `build:` section, which RTD v2 requires, so a Read the Docs build would have failed
- Remaining Sphinx warnings fixed; docs now build with zero warnings

**Documentation accuracy**
- The documented `pytest tests/ -v` command fails. The inherited integration tests need a live server at 127.0.0.1:3001 and their `setUp` deletes every monitor, notification, proxy, tag, status page, docker host, maintenance, and API key on it. README now lists the six safe v2 files and carries that warning.
- Replaced the Read the Docs link, which pointed at the upstream project and documents none of this fork's v2 features, with local Sphinx build instructions

**Packaging**
- Added `project_urls` (Source, Changelog, Issues) for the PyPI sidebar
- Added Python 3.12 / 3.13 classifiers to match the CI matrix
- Added `build/` to `.gitignore`; removed three stale `.egg-info` directories left from the rename churn

**BREAKING: Python 3.7 dropped**
- `python_requires` is now `>=3.8, <4`; 3.7 classifier removed. 3.7 has been EOL since June 2023 and was never in the CI matrix, so the old floor was an untested claim. 3.7 users resolve to 2.1.0 or earlier.
- Released as 2.2.0 rather than 2.1.1, since raising the floor changes install resolution rather than being a pure patch.

## Verification

- 86 unit tests pass
- `twine check` passes on both sdist and wheel
- Sphinx builds clean, zero warnings
- `import uptime_kuma_api` emits no warnings
- Built sdist metadata confirmed: `Requires-Python: >=3.8, <4`, classifiers 3.8-3.13 only
