### PR TITLE
ci: gate PyPI publish on tests, run tests on branch pushes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,22 +6,63 @@ on:
       - "v*"
 
 jobs:
+  # Gate: a PyPI upload cannot be undone and the version number is burned
+  # permanently, so tests and a tag/version match are verified before building.
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.8", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          pip install -e .
+          pip install pytest
+
+      - name: Run unit tests
+        run: |
+          pytest tests/test_monitor_types_v2.py tests/test_monitor_params_v2.py \
+                 tests/test_status_page_v2.py tests/test_notification_v2.py \
+                 tests/test_logger.py tests/test_monitor_builder.py -v
+
   publish:
+    needs: test
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
+
+      - name: Verify tag matches __version__
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg=$(python -c "info={}; exec(open('uptime_kuma_api/__version__.py').read(), info); print(info['__version__'])")
+          echo "tag=$tag package=$pkg"
+          if [ "$tag" != "$pkg" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match __version__ $pkg"
+            exit 1
+          fi
 
       - name: Install build tools
         run: pip install build twine
 
       - name: Build package
         run: python -m build
+
+      - name: Check distribution metadata
+        run: twine check dist/*
 
       - name: Upload to PyPI
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,23 +1,71 @@
 name: Tests
 
+# Branch pushes get a fast single-version run so feedback does not wait for a PR.
+# main, PRs and release tags get the full matrix.
 on:
   push:
-    branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+
+# A newer push to the same ref supersedes an in-flight run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  # The v2 unit tests run without a live Uptime Kuma server. The remaining test
+  # files are integration tests that require an instance at 127.0.0.1:3001 and
+  # delete all of its data, so they are never run in CI.
+  V2_TESTS: >-
+    tests/test_monitor_types_v2.py
+    tests/test_monitor_params_v2.py
+    tests/test_status_page_v2.py
+    tests/test_notification_v2.py
+    tests/test_logger.py
+    tests/test_monitor_builder.py
 
 jobs:
-  test:
+  quick:
+    name: quick (3.11)
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' &&
+       github.ref != 'refs/heads/main' &&
+       !startsWith(github.ref, 'refs/tags/'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          pip install -e .
+          pip install pytest
+
+      - name: Run unit tests
+        run: pytest ${{ env.V2_TESTS }} -v
+
+  full:
+    name: full
+    if: >-
+      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/main' ||
+      startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -27,5 +75,4 @@ jobs:
           pip install pytest
 
       - name: Run unit tests
-        run: |
-          pytest tests/test_monitor_types_v2.py tests/test_monitor_params_v2.py tests/test_status_page_v2.py tests/test_notification_v2.py tests/test_logger.py tests/test_monitor_builder.py -v
+        run: pytest ${{ env.V2_TESTS }} -v


### PR DESCRIPTION
Two problems in the release path, plus an ergonomics fix.

## 1. Publishing was not gated on tests (the important one)

`publish.yml` ran checkout -> build -> `twine upload` with **no test step**, and no dependency on the Tests workflow. Pushing a tag uploaded to PyPI regardless of whether anything passed.

v2.2.0 was only tested because it happened to be routed through a PR. Tagging directly on `main` would have published untested. A PyPI version number is burned permanently and a filename can never be re-uploaded, so this was the one unrecoverable failure mode in the pipeline.

Now: `publish` `needs:` a `test` job (3.8 and 3.13, the range ends), so a red suite blocks the upload.

Also added:
- **Tag/version match check.** Fails before building if the pushed tag does not match `__version__`, catching e.g. a `v2.2.0` tag against a `2.1.1` version file before it reaches PyPI.
- `twine check` before upload, rather than only relying on it being run locally.

## 2. Tests only ran on main and PRs

`push: branches: [main]` meant pushing a feature branch ran nothing until a PR existed. Now runs on all branch pushes.

Tiered to keep this cheap:
- **branch push** -> `quick` job, single version (3.11)
- **main, PRs, release tags** -> `full` 3.8-3.13 matrix

Plus a `concurrency` group so a newer push supersedes an in-flight run, and `workflow_dispatch` for manual triggering.

Verified on this branch: the push ran `quick (3.11)` -> success with `full` -> skipped, in 16s, with no PR open. This PR should invert that.

## 3. Node.js 20 deprecation

The v2.2.0 publish run warned that `actions/checkout@v4` and `actions/setup-python@v5` target Node 20 and were being forced onto Node 24. Both bumped to `@v7` (current major for each).

## Notes

- The v2 test file list is now a workflow-level env var, with a comment recording why the inherited integration tests are excluded from CI: they need a live instance at 127.0.0.1:3001 and delete all of its data.
- No library code is touched. Workflow files only.
- Deliberately **not** adding a pre-push git hook: hooks are not shared through git, `--no-verify` bypasses them, and the 0.66s suite can already be run manually. The CI gate is the enforcement boundary.
