### PR TITLE
test: verify live integration round-trips, add config backup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ docs/_build
 .env
 tests/.env
 tests/.live_test_ids.json
+# Config snapshots from live_test_backup.py — contain plaintext secrets
+tests/.backups/

--- a/tests/live_test_backup.py
+++ b/tests/live_test_backup.py
@@ -1,0 +1,147 @@
+"""
+Export the full configuration of a live Uptime Kuma instance to a local JSON file.
+
+Read-only. Creates and modifies nothing on the server.
+
+Why this exists: Uptime Kuma has no download-backup endpoint (only
+``upload_backup`` for importing its own legacy format), so there is no API call
+that produces a real database backup. This script instead walks every read
+endpoint and records the result, giving a point-in-time snapshot of what was
+configured before a live test run.
+
+SCOPE AND LIMITS — read this before relying on it:
+  - This is a *reference snapshot*, not a one-click restore. The format is this
+    script's own, not Uptime Kuma's backup format, so ``upload_backup`` will
+    not consume it. Restoring means re-creating resources from the recorded
+    fields, by hand or by script.
+  - Heartbeat/history data is NOT included, only configuration.
+  - For a genuinely restorable backup, snapshot the server's SQLite file or
+    container volume. See the instructions this script prints on completion.
+
+THE OUTPUT CONTAINS SECRETS: notification API keys, monitor basic-auth
+passwords, proxy passwords and API keys are all included in plain text. Files
+are written to tests/.backups/, which is gitignored. Do not commit or share them.
+
+Usage:
+    .venv/Scripts/python tests/live_test_backup.py
+"""
+import datetime
+import json
+import os
+import sys
+
+sys.path.insert(0, ".")
+
+from dotenv import load_dotenv
+
+load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
+
+from uptime_kuma_api import UptimeKumaApi
+
+BACKUP_DIR = os.path.join("tests", ".backups")
+
+
+def main() -> int:
+    try:
+        url = os.environ["UPTIME_KUMA_URL"]
+        username = os.environ["UPTIME_KUMA_USERNAME"]
+        password = os.environ["UPTIME_KUMA_PASSWORD"]
+    except KeyError as e:
+        raise SystemExit(f"ABORT: {e.args[0]} is not set in tests/.env")
+
+    print(f"Connecting to {url} ...")
+    api = UptimeKumaApi(url)
+
+    snapshot = {}
+    errors = {}
+
+    try:
+        api.login(username, password)
+        version = api.version
+        print(f"  connected, server version {version}")
+
+        snapshot["_meta"] = {
+            "exported_at": datetime.datetime.now().astimezone().isoformat(),
+            "server_url": url,
+            "server_version": version,
+            "note": "Configuration snapshot only. No heartbeat history. "
+                    "Not restorable via upload_backup.",
+        }
+
+        # Each section is fetched independently so one unsupported endpoint
+        # cannot abort the whole export.
+        sections = {
+            "monitors": api.get_monitors,
+            "notifications": api.get_notifications,
+            "proxies": api.get_proxies,
+            "tags": api.get_tags,
+            "status_pages": api.get_status_pages,
+            "maintenances": api.get_maintenances,
+            "docker_hosts": api.get_docker_hosts,
+            "api_keys": api.get_api_keys,
+            "settings": api.get_settings,
+        }
+
+        print()
+        for name, fetch in sections.items():
+            try:
+                data = fetch()
+                snapshot[name] = data
+                count = len(data) if isinstance(data, (list, dict)) else 1
+                print(f"  {name:<16} {count}")
+            except Exception as e:
+                errors[name] = f"{type(e).__name__}: {e}"
+                snapshot[name] = None
+                print(f"  {name:<16} FAILED ({type(e).__name__})")
+
+        # Status page detail lives behind a per-slug call, so fetch each one.
+        if snapshot.get("status_pages"):
+            details = {}
+            for page in snapshot["status_pages"]:
+                slug = page.get("slug")
+                if not slug:
+                    continue
+                try:
+                    details[slug] = api.get_status_page(slug)
+                except Exception as e:
+                    errors[f"status_page:{slug}"] = f"{type(e).__name__}: {e}"
+            snapshot["status_page_details"] = details
+            print(f"  {'status_page_detl':<16} {len(details)}")
+
+    finally:
+        api.disconnect()
+
+    if errors:
+        snapshot["_meta"]["errors"] = errors
+
+    os.makedirs(BACKUP_DIR, exist_ok=True)
+    stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    path = os.path.join(BACKUP_DIR, f"config_snapshot_{stamp}.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(snapshot, f, indent=2, default=str)
+
+    size = os.path.getsize(path)
+    print()
+    print(f"Wrote {path} ({size:,} bytes)")
+
+    if errors:
+        print()
+        print(f"WARNING: {len(errors)} section(s) failed to export:")
+        for key, msg in errors.items():
+            print(f"  {key}: {msg}")
+        print("The snapshot is incomplete. Treat it accordingly.")
+
+    print()
+    print("This file contains secrets in plain text. It is gitignored; keep it local.")
+    print()
+    print("For a genuinely restorable backup, snapshot the database on the server:")
+    print("  Docker:       docker cp <container>:/app/data/kuma.db ./kuma.db.bak")
+    print("                (or back up the mounted volume directory)")
+    print("  Bare install: cp /path/to/uptime-kuma/data/kuma.db ./kuma.db.bak")
+    print("  Safest is to stop the container first so the file is quiescent.")
+
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/live_test_cleanup.py
+++ b/tests/live_test_cleanup.py
@@ -1,131 +1,183 @@
 """
 Live integration test — CLEANUP phase.
 
-Connects to the live Uptime Kuma v2 instance and removes all test
-resources created by `live_test_create.py`.
+Removes the resources created by live_test_create.py from the live Uptime Kuma
+instance.
 
-Reads resource IDs from `tests/.live_test_ids.json` (saved by the
-creation script). Also scans for any [TEST]-prefixed resources that
-might have been missed.
+Deletion targets two overlapping sets:
+  1. IDs recorded in tests/.live_test_ids.json during creation
+  2. anything named with the "[TEST] " prefix
+
+The prefix sweep exists to catch orphans when the creation script fails partway
+through. It means this script will delete ANY resource whose name starts with
+"[TEST] ", including resources it did not create. Check the plan it prints
+before confirming if that matters to you.
+
+Output is deliberately ASCII only. The Windows console defaults to cp1252 and
+raises UnicodeEncodeError on characters like check marks, which previously
+crashed this script before it deleted anything.
 
 Configuration:
-    Create a `tests/.env` file with:
+    Create a tests/.env file with:
         UPTIME_KUMA_URL=http://your-host:3001/
         UPTIME_KUMA_USERNAME=admin
         UPTIME_KUMA_PASSWORD=your-password
 
 Usage:
     .venv/Scripts/python tests/live_test_cleanup.py
+    .venv/Scripts/python tests/live_test_cleanup.py --dry-run
 """
+import argparse
+import json
 import os
 import sys
-import json
 
 sys.path.insert(0, ".")
 
 from dotenv import load_dotenv
+
 load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
 
 from uptime_kuma_api import UptimeKumaApi
 
-URL = os.environ["UPTIME_KUMA_URL"]
-USERNAME = os.environ["UPTIME_KUMA_USERNAME"]
-PASSWORD = os.environ["UPTIME_KUMA_PASSWORD"]
-
 PREFIX = "[TEST] "
-IDS_FILE = "tests/.live_test_ids.json"
+IDS_FILE = os.path.join("tests", ".live_test_ids.json")
 
 
-def main():
-    print(f"Connecting to {URL}...")
-    api = UptimeKumaApi(URL)
+def load_saved_ids() -> dict:
+    saved = {"monitors": [], "notifications": [], "status_pages": []}
+    if not os.path.exists(IDS_FILE):
+        print(f"  no {IDS_FILE}; falling back to '{PREFIX}' name matching only")
+        return saved
+    with open(IDS_FILE) as f:
+        loaded = json.load(f)
+    for key in saved:
+        saved[key] = loaded.get(key, [])
+    print(f"  loaded IDs from {IDS_FILE}")
+    return saved
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Remove [TEST] resources.")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="list what would be deleted without deleting anything",
+    )
+    args = parser.parse_args()
 
     try:
-        api.login(USERNAME, PASSWORD)
-        print(f"✓ Connected. Server version: {api.version}")
+        url = os.environ["UPTIME_KUMA_URL"]
+        username = os.environ["UPTIME_KUMA_USERNAME"]
+        password = os.environ["UPTIME_KUMA_PASSWORD"]
+    except KeyError as e:
+        raise SystemExit(f"ABORT: {e.args[0]} is not set in tests/.env")
+
+    print(f"Connecting to {url} ...")
+    api = UptimeKumaApi(url)
+    deleted = {"monitors": 0, "notifications": 0, "status_pages": 0}
+    kept = {"monitors": 0, "notifications": 0, "status_pages": 0}
+    failures = []
+
+    try:
+        api.login(username, password)
+        print(f"  connected, server version {api.version}")
+        saved = load_saved_ids()
         print()
 
-        # Load saved IDs if available
-        saved_ids = {"monitors": [], "notifications": [], "status_pages": []}
-        if os.path.exists(IDS_FILE):
-            with open(IDS_FILE, "r") as f:
-                saved_ids = json.load(f)
-            print(f"  Loaded saved IDs from {IDS_FILE}")
-        else:
-            print(f"  No saved IDs file found — will scan for [TEST] prefixed resources")
+        if args.dry_run:
+            print("DRY RUN - nothing will be deleted")
+            print()
 
-        deleted = {"monitors": 0, "notifications": 0, "status_pages": 0}
-
-        # ═══════════════════════════════════════════════════════════════════
-        # 1. Delete monitors (by saved ID + scan for [TEST] prefix)
-        # ═══════════════════════════════════════════════════════════════════
-        print()
-        print("─── Cleaning up monitors ───")
-
-        monitors = api.get_monitors()
-        for monitor in monitors:
-            should_delete = (
-                monitor["id"] in saved_ids["monitors"]
-                or monitor["name"].startswith(PREFIX)
-            )
-            if should_delete:
+        print("Monitors")
+        for monitor in api.get_monitors():
+            match = monitor["id"] in saved["monitors"] or monitor["name"].startswith(PREFIX)
+            if not match:
+                kept["monitors"] += 1
+                continue
+            label = f"id={monitor['id']} name={monitor['name']!r}"
+            if args.dry_run:
+                print(f"  WOULD DELETE {label}")
+                continue
+            try:
                 api.delete_monitor(monitor["id"])
-                print(f"  ✗ Deleted monitor: id={monitor['id']} name={monitor['name']}")
                 deleted["monitors"] += 1
+                print(f"  deleted {label}")
+            except Exception as e:
+                failures.append(f"monitor {label}: {type(e).__name__}: {e}")
+                print(f"  FAILED  {label}: {type(e).__name__}")
 
-        # ═══════════════════════════════════════════════════════════════════
-        # 2. Delete notifications (by saved ID + scan for [TEST] prefix)
-        # ═══════════════════════════════════════════════════════════════════
         print()
-        print("─── Cleaning up notifications ───")
-
-        notifications = api.get_notifications()
-        for notification in notifications:
-            should_delete = (
-                notification["id"] in saved_ids["notifications"]
-                or notification["name"].startswith(PREFIX)
-            )
-            if should_delete:
+        print("Notifications")
+        for notification in api.get_notifications():
+            name = notification.get("name", "")
+            match = notification["id"] in saved["notifications"] or name.startswith(PREFIX)
+            if not match:
+                kept["notifications"] += 1
+                continue
+            label = f"id={notification['id']} name={name!r}"
+            if args.dry_run:
+                print(f"  WOULD DELETE {label}")
+                continue
+            try:
                 api.delete_notification(notification["id"])
-                print(f"  ✗ Deleted notification: id={notification['id']} name={notification['name']}")
                 deleted["notifications"] += 1
+                print(f"  deleted {label}")
+            except Exception as e:
+                failures.append(f"notification {label}: {type(e).__name__}: {e}")
+                print(f"  FAILED  {label}: {type(e).__name__}")
 
-        # ═══════════════════════════════════════════════════════════════════
-        # 3. Delete status pages (by saved slug + scan for [TEST] prefix)
-        # ═══════════════════════════════════════════════════════════════════
         print()
-        print("─── Cleaning up status pages ───")
-
-        status_pages = api.get_status_pages()
-        for sp in status_pages:
-            should_delete = (
-                sp["slug"] in saved_ids["status_pages"]
-                or sp.get("title", "").startswith(PREFIX)
-            )
-            if should_delete:
-                api.delete_status_page(sp["slug"])
-                print(f"  ✗ Deleted status page: slug={sp['slug']} title={sp.get('title', '?')}")
+        print("Status pages")
+        for page in api.get_status_pages():
+            slug = page.get("slug")
+            title = str(page.get("title", ""))
+            match = slug in saved["status_pages"] or title.startswith(PREFIX)
+            if not match:
+                kept["status_pages"] += 1
+                continue
+            label = f"slug={slug!r} title={title!r}"
+            if args.dry_run:
+                print(f"  WOULD DELETE {label}")
+                continue
+            try:
+                api.delete_status_page(slug)
                 deleted["status_pages"] += 1
-
-        # ═══════════════════════════════════════════════════════════════════
-        # Summary
-        # ═══════════════════════════════════════════════════════════════════
-        print()
-        print("═══════════════════════════════════════════════════")
-        print("  CLEANUP COMPLETE")
-        print("═══════════════════════════════════════════════════")
-        print(f"  Monitors deleted:      {deleted['monitors']}")
-        print(f"  Notifications deleted: {deleted['notifications']}")
-        print(f"  Status pages deleted:  {deleted['status_pages']}")
-
-        # Remove the IDs file
-        if os.path.exists(IDS_FILE):
-            os.remove(IDS_FILE)
-            print(f"  Removed {IDS_FILE}")
+                print(f"  deleted {label}")
+            except Exception as e:
+                failures.append(f"status page {label}: {type(e).__name__}: {e}")
+                print(f"  FAILED  {label}: {type(e).__name__}")
 
     finally:
         api.disconnect()
 
+    print()
+    print("=" * 60)
+    if args.dry_run:
+        print("  DRY RUN complete - nothing deleted")
+    else:
+        print(f"  deleted: {deleted['monitors']} monitors, "
+              f"{deleted['notifications']} notifications, "
+              f"{deleted['status_pages']} status pages")
+    print(f"  left untouched: {kept['monitors']} monitors, "
+          f"{kept['notifications']} notifications, "
+          f"{kept['status_pages']} status pages")
+    print("=" * 60)
+
+    if failures:
+        print()
+        print(f"{len(failures)} deletion(s) failed:")
+        for f in failures:
+            print(f"  {f}")
+        print("Re-run to retry, or remove them in the UI.")
+        return 1
+
+    if not args.dry_run and os.path.exists(IDS_FILE):
+        os.remove(IDS_FILE)
+        print(f"\nremoved {IDS_FILE}")
+
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/live_test_create.py
+++ b/tests/live_test_create.py
@@ -1,163 +1,296 @@
 """
-Live integration test — CREATION phase.
+Live integration test — CREATION and VERIFICATION phase.
 
-Connects to a live Uptime Kuma v2 instance and creates test resources
-to verify all new v2 features work end-to-end. Resources are prefixed
-with "[TEST]" for easy identification and cleanup.
+Connects to a live Uptime Kuma v2 instance, creates one resource for every
+feature added in 2.1.0, then reads each one back and compares the fields the
+server returned against the fields that were sent.
 
-After running this script, inspect the resources in the Uptime Kuma UI.
-Then run `live_test_cleanup.py` to remove them.
+This round-trip comparison is the point of the script. A server that silently
+drops or renames a field looks identical to success from the client side, so
+creating a resource without reading it back proves very little.
+
+What a failure means:
+    ABSENT     the server did not return the field at all — it was probably
+               dropped, ignored, or the library is sending the wrong key
+    MISMATCH   the server returned a different value than was sent — likely a
+               type or format problem (e.g. sending int where str is expected)
+
+Monitors created here intentionally point at unreachable targets, so they will
+show as DOWN in the UI. That is expected. This script tests whether the server
+accepts and persists the configuration, not whether the target responds.
+
+Resources are named with a "[TEST] " prefix and their IDs are written to
+tests/.live_test_ids.json after each creation, so live_test_cleanup.py can
+remove them even if this script fails partway through.
 
 Configuration:
-    Create a `tests/.env` file with:
+    Create a tests/.env file with:
         UPTIME_KUMA_URL=http://your-host:3001/
         UPTIME_KUMA_USERNAME=admin
         UPTIME_KUMA_PASSWORD=your-password
 
 Usage:
     .venv/Scripts/python tests/live_test_create.py
+    .venv/Scripts/python tests/live_test_create.py --allow-default-notifications
+
+Exit code is 0 only if every round-trip check passed.
 """
+import argparse
+import json
 import os
 import sys
-import json
 
 sys.path.insert(0, ".")
 
 from dotenv import load_dotenv
+
 load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
 
-from uptime_kuma_api import UptimeKumaApi, MonitorType, MonitorBuilder, NotificationType
+from packaging.version import parse as parse_version
 
-URL = os.environ["UPTIME_KUMA_URL"]
-USERNAME = os.environ["UPTIME_KUMA_USERNAME"]
-PASSWORD = os.environ["UPTIME_KUMA_PASSWORD"]
+from uptime_kuma_api import (
+    MonitorBuilder,
+    MonitorType,
+    NotificationType,
+    UptimeKumaApi,
+)
 
 PREFIX = "[TEST] "
+IDS_FILE = os.path.join("tests", ".live_test_ids.json")
+
+created = {"monitors": [], "notifications": [], "status_pages": []}
+results = []
 
 
-def main():
-    print(f"Connecting to {URL}...")
-    api = UptimeKumaApi(URL)
+def save_ids():
+    """Persist created IDs after every creation so cleanup can always recover."""
+    os.makedirs(os.path.dirname(IDS_FILE), exist_ok=True)
+    with open(IDS_FILE, "w") as f:
+        json.dump(created, f, indent=2)
+
+
+def equivalent(expected, actual) -> bool:
+    """
+    Compare a sent value against a returned value, tolerating the type coercion
+    Uptime Kuma applies on the way through its database.
+
+    Deliberately tolerant about representation (bool as 0/1, numbers as
+    strings, lists as JSON strings) and strict about actual value differences.
+    """
+    if expected == actual:
+        return True
+
+    # Uptime Kuma stores booleans as integers in some columns.
+    if isinstance(expected, bool):
+        if isinstance(actual, (int, float)) and not isinstance(actual, bool):
+            return bool(actual) is expected
+        if isinstance(actual, str):
+            lowered = actual.strip().lower()
+            if lowered in ("1", "true"):
+                return expected is True
+            if lowered in ("0", "false"):
+                return expected is False
+        return False
+
+    # Numbers may come back as strings, or vice versa.
+    if isinstance(expected, (int, float)) and isinstance(actual, str):
+        try:
+            return float(actual) == float(expected)
+        except ValueError:
+            return False
+    if isinstance(expected, str) and isinstance(actual, (int, float)) and not isinstance(actual, bool):
+        try:
+            return float(expected) == float(actual)
+        except ValueError:
+            return False
+
+    # Lists are sent JSON-encoded for some fields (e.g. rabbitmqNodes).
+    if isinstance(expected, list) and isinstance(actual, str):
+        try:
+            return json.loads(actual) == expected
+        except (ValueError, TypeError):
+            return False
+
+    return False
+
+
+def record(label: str, ok: bool, detail: str = "") -> bool:
+    """Record one check result and report it as it happens."""
+    results.append((label, ok, detail))
+    print(f"  {'PASS' if ok else 'FAIL'}  {label}")
+    if not ok and detail:
+        print(f"          {detail}")
+    return ok
+
+
+def check(label: str, sent: dict, got: dict) -> bool:
+    """Verify every field in `sent` came back intact in `got`."""
+    absent = [key for key in sent if key not in got]
+    mismatched = [
+        f"{key}: sent {value!r}, got {got[key]!r}"
+        for key, value in sent.items()
+        if key in got and not equivalent(value, got[key])
+    ]
+
+    parts = []
+    if absent:
+        parts.append("ABSENT: " + ", ".join(absent))
+    if mismatched:
+        parts.append("MISMATCH: " + "; ".join(mismatched))
+
+    return record(label, not parts, "  ".join(parts))
+
+
+def check_absent(label: str, key: str, got: dict) -> bool:
+    """Verify a field is *not* present, for fields v2 is expected to drop."""
+    absent = key not in got
+    detail = "" if absent else f"UNEXPECTED: {key} still present: {got[key]!r}"
+    return record(label, absent, detail)
+
+
+def add_monitor(api, label: str, verify: dict, **kwargs) -> int:
+    """Create a monitor, register it for cleanup, then verify the round-trip.
+
+    `verify` holds the fields to compare after reading the monitor back. It is
+    kept separate from `kwargs` because some sent values are transformed by the
+    library before transmission (e.g. rabbitmqNodes is JSON-encoded), so what
+    should come back is not always identical to what was passed in.
+    """
+    r = api.add_monitor(name=f"{PREFIX}{label}", **kwargs)
+    monitor_id = r["monitorID"]
+    created["monitors"].append(monitor_id)
+    save_ids()
+
+    got = api.get_monitor(monitor_id)
+    check(f"monitor {label} (id={monitor_id})", verify, got)
+    return monitor_id
+
+
+def add_notification(api, label: str, verify: dict, **kwargs) -> int:
+    r = api.add_notification(name=f"{PREFIX}{label}", **kwargs)
+    notification_id = r["id"]
+    created["notifications"].append(notification_id)
+    save_ids()
+
+    got = api.get_notification(notification_id)
+    check(f"notification {label} (id={notification_id})", verify, got)
+    return notification_id
+
+
+def preflight(api, allow_default_notifications: bool) -> None:
+    """Refuse to run where the results would be meaningless or disruptive."""
+    version = api.version
+    print(f"  server version: {version}")
+
+    if parse_version(version) < parse_version("2.0"):
+        raise SystemExit(
+            f"ABORT: this script tests v2-only features but the server is {version}.\n"
+            "       Point tests/.env at an Uptime Kuma 2.x instance."
+        )
+
+    # Uptime Kuma attaches notifications flagged as default to every new
+    # monitor. These monitors are meant to be DOWN, so a default notification
+    # would fire an alert for each one.
+    defaults = [n for n in api.get_notifications() if n.get("isDefault")]
+    if defaults and not allow_default_notifications:
+        names = ", ".join(repr(n.get("name")) for n in defaults)
+        raise SystemExit(
+            f"ABORT: {len(defaults)} default notification(s) found: {names}\n"
+            "       Every monitor created here is intentionally unreachable, so these\n"
+            "       would send a DOWN alert for each one.\n"
+            "       Disable 'Default enabled' on them, or re-run with\n"
+            "       --allow-default-notifications to accept the alerts."
+        )
+    if defaults:
+        print(f"  WARNING: {len(defaults)} default notification(s) will fire DOWN alerts")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--allow-default-notifications",
+        action="store_true",
+        help="proceed even though default notifications will alert on the test monitors",
+    )
+    args = parser.parse_args()
 
     try:
-        api.login(USERNAME, PASSWORD)
-        print(f"✓ Connected. Server version: {api.version}")
+        url = os.environ["UPTIME_KUMA_URL"]
+        username = os.environ["UPTIME_KUMA_USERNAME"]
+        password = os.environ["UPTIME_KUMA_PASSWORD"]
+    except KeyError as e:
+        raise SystemExit(
+            f"ABORT: {e.args[0]} is not set. Create tests/.env with "
+            "UPTIME_KUMA_URL, UPTIME_KUMA_USERNAME and UPTIME_KUMA_PASSWORD."
+        )
+
+    print(f"Connecting to {url} ...")
+    api = UptimeKumaApi(url)
+
+    try:
+        api.login(username, password)
+        print("  connected")
+        preflight(api, args.allow_default_notifications)
         print()
 
-        created = {"monitors": [], "notifications": [], "status_pages": []}
-
-        # ═══════════════════════════════════════════════════════════════════
-        # 1. New Monitor Types
-        # ═══════════════════════════════════════════════════════════════════
-        print("─── Creating new monitor types ───")
-
-        # SMTP monitor (most likely to succeed — just needs a hostname)
-        r = api.add_monitor(
-            type=MonitorType.SMTP,
-            name=f"{PREFIX}SMTP Monitor",
-            hostname="smtp.gmail.com",
-            port=587,
+        print("New monitor types")
+        add_monitor(
+            api, "SMTP Monitor",
+            verify={"type": MonitorType.SMTP, "hostname": "smtp.gmail.com",
+                    "port": 587, "smtpSecurity": "starttls"},
+            type=MonitorType.SMTP, hostname="smtp.gmail.com", port=587,
             smtpSecurity="starttls",
         )
-        print(f"  ✓ SMTP monitor created: id={r['monitorID']}")
-        created["monitors"].append(r["monitorID"])
-
-        # SNMP monitor
-        r = api.add_monitor(
-            type=MonitorType.SNMP,
-            name=f"{PREFIX}SNMP Monitor",
-            hostname="10.0.0.1",
-            port=161,
-            snmpOid="1.3.6.1.2.1.1.1.0",
-            snmpVersion="2c",
+        add_monitor(
+            api, "SNMP Monitor",
+            verify={"type": MonitorType.SNMP, "hostname": "10.0.0.1", "port": 161,
+                    "snmpOid": "1.3.6.1.2.1.1.1.0", "snmpVersion": "2c"},
+            type=MonitorType.SNMP, hostname="10.0.0.1", port=161,
+            snmpOid="1.3.6.1.2.1.1.1.0", snmpVersion="2c",
         )
-        print(f"  ✓ SNMP monitor created: id={r['monitorID']}")
-        created["monitors"].append(r["monitorID"])
-
-        # RabbitMQ monitor
-        r = api.add_monitor(
-            type=MonitorType.RABBITMQ,
-            name=f"{PREFIX}RabbitMQ Monitor",
-            rabbitmqNodes=["amqp://localhost:5672"],
-            rabbitmqUsername="guest",
-            rabbitmqPassword="guest",
+        add_monitor(
+            api, "RabbitMQ Monitor",
+            verify={"type": MonitorType.RABBITMQ,
+                    "rabbitmqNodes": ["amqp://localhost:5672"],
+                    "rabbitmqUsername": "guest", "rabbitmqPassword": "guest"},
+            type=MonitorType.RABBITMQ, rabbitmqNodes=["amqp://localhost:5672"],
+            rabbitmqUsername="guest", rabbitmqPassword="guest",
         )
-        print(f"  ✓ RabbitMQ monitor created: id={r['monitorID']}")
-        created["monitors"].append(r["monitorID"])
-
-        # System Service monitor
-        r = api.add_monitor(
-            type=MonitorType.SYSTEM_SERVICE,
-            name=f"{PREFIX}System Service Monitor",
-            system_service_name="nginx",
+        add_monitor(
+            api, "System Service Monitor",
+            verify={"type": MonitorType.SYSTEM_SERVICE, "system_service_name": "nginx"},
+            type=MonitorType.SYSTEM_SERVICE, system_service_name="nginx",
         )
-        print(f"  ✓ System Service monitor created: id={r['monitorID']}")
-        created["monitors"].append(r["monitorID"])
 
-        # ═══════════════════════════════════════════════════════════════════
-        # 2. v2 Monitor Parameters (HTTP with new fields)
-        # ═══════════════════════════════════════════════════════════════════
         print()
-        print("─── Creating HTTP monitor with v2 params ───")
-
-        r = api.add_monitor(
-            type=MonitorType.HTTP,
-            name=f"{PREFIX}HTTP v2 Params",
-            url="https://httpbin.org/get",
-            ipFamily="IPv4",
-            cacheBust=True,
-            saveResponse=True,
-            saveErrorResponse=True,
-            responseMaxLength=5000,
-            domainExpiryNotification=True,
+        print("v2 monitor parameters")
+        add_monitor(
+            api, "HTTP v2 Params",
+            verify={"url": "https://httpbin.org/get", "ipFamily": "IPv4",
+                    "cacheBust": True, "saveResponse": True,
+                    "saveErrorResponse": True, "responseMaxLength": 5000,
+                    "domainExpiryNotification": True},
+            type=MonitorType.HTTP, url="https://httpbin.org/get", ipFamily="IPv4",
+            cacheBust=True, saveResponse=True, saveErrorResponse=True,
+            responseMaxLength=5000, domainExpiryNotification=True,
         )
-        print(f"  ✓ HTTP monitor with v2 params created: id={r['monitorID']}")
-        created["monitors"].append(r["monitorID"])
-
-        # Verify round-trip
-        mon = api.get_monitor(r["monitorID"])
-        assert mon.get("ipFamily") is not None or True  # server may return as different key
-        print(f"    Round-trip check: name={mon['name']}")
-
-        # ═══════════════════════════════════════════════════════════════════
-        # 3. JSON_QUERY with jsonPathOperator
-        # ═══════════════════════════════════════════════════════════════════
-        print()
-        print("─── Creating JSON_QUERY monitor with jsonPathOperator ───")
-
-        r = api.add_monitor(
-            type=MonitorType.JSON_QUERY,
-            name=f"{PREFIX}JSON Query Operator",
-            url="https://httpbin.org/json",
-            jsonPath="$.slideshow.title",
-            expectedValue="Sample",
+        add_monitor(
+            api, "JSON Query Operator",
+            verify={"jsonPath": "$.slideshow.title", "expectedValue": "Sample",
+                    "jsonPathOperator": "contains"},
+            type=MonitorType.JSON_QUERY, url="https://httpbin.org/json",
+            jsonPath="$.slideshow.title", expectedValue="Sample",
             jsonPathOperator="contains",
         )
-        print(f"  ✓ JSON_QUERY monitor created: id={r['monitorID']}")
-        created["monitors"].append(r["monitorID"])
-
-        # ═══════════════════════════════════════════════════════════════════
-        # 4. PING with v2 params
-        # ═══════════════════════════════════════════════════════════════════
-        print()
-        print("─── Creating PING monitor with v2 params ───")
-
-        r = api.add_monitor(
-            type=MonitorType.PING,
-            name=f"{PREFIX}PING v2 Params",
-            hostname="8.8.8.8",
-            ping_count=3,
+        add_monitor(
+            api, "PING v2 Params",
+            verify={"hostname": "8.8.8.8", "ping_count": 3, "ping_numeric": True},
+            type=MonitorType.PING, hostname="8.8.8.8", ping_count=3,
             ping_numeric=True,
         )
-        print(f"  ✓ PING monitor with v2 params created: id={r['monitorID']}")
-        created["monitors"].append(r["monitorID"])
 
-        # ═══════════════════════════════════════════════════════════════════
-        # 5. MonitorBuilder end-to-end
-        # ═══════════════════════════════════════════════════════════════════
         print()
-        print("─── Creating monitor via MonitorBuilder ───")
-
+        print("MonitorBuilder end-to-end")
         config = (
             MonitorBuilder()
             .type(MonitorType.HTTP)
@@ -171,56 +304,58 @@ def main():
             .build()
         )
         r = api.add_monitor(**config)
-        print(f"  ✓ MonitorBuilder monitor created: id={r['monitorID']}")
-        created["monitors"].append(r["monitorID"])
+        builder_id = r["monitorID"]
+        created["monitors"].append(builder_id)
+        save_ids()
+        got = api.get_monitor(builder_id)
+        check(
+            f"monitor MonitorBuilder Test (id={builder_id})",
+            {"url": "https://example.com", "interval": 120},
+            got,
+        )
 
-        # ═══════════════════════════════════════════════════════════════════
-        # 6. Notification Providers
-        # ═══════════════════════════════════════════════════════════════════
         print()
-        print("─── Creating new notification providers ───")
-
-        # Brevo (won't actually send, but validates server accepts it)
-        r = api.add_notification(
-            name=f"{PREFIX}Brevo Notification",
+        print("New notification providers")
+        add_notification(
+            api, "Brevo Notification",
+            verify={"type": NotificationType.BREVO,
+                    "brevoApiKey": "xkeysib-test-key-12345",
+                    "brevoFromEmail": "test@example.com",
+                    "brevoToEmail": "recipient@example.com"},
             type=NotificationType.BREVO,
             brevoApiKey="xkeysib-test-key-12345",
             brevoFromEmail="test@example.com",
             brevoToEmail="recipient@example.com",
         )
-        print(f"  ✓ Brevo notification created: id={r['id']}")
-        created["notifications"].append(r["id"])
-
-        # Evolution API
-        r = api.add_notification(
-            name=f"{PREFIX}Evolution API Notification",
+        add_notification(
+            api, "Evolution API Notification",
+            verify={"type": NotificationType.EVOLUTION_API,
+                    "evolutionInstanceName": "test-instance",
+                    "evolutionAuthToken": "test-token-123",
+                    "evolutionRecipient": "5511999999999"},
             type=NotificationType.EVOLUTION_API,
             evolutionInstanceName="test-instance",
             evolutionAuthToken="test-token-123",
             evolutionRecipient="5511999999999",
         )
-        print(f"  ✓ Evolution API notification created: id={r['id']}")
-        created["notifications"].append(r["id"])
-
-        # Nextcloud Talk
-        r = api.add_notification(
-            name=f"{PREFIX}Nextcloud Talk Notification",
+        add_notification(
+            api, "Nextcloud Talk Notification",
+            verify={"type": NotificationType.NEXTCLOUD_TALK,
+                    "host": "https://nextcloud.example.com",
+                    "conversationToken": "test-token",
+                    "botSecret": "test-secret"},
             type=NotificationType.NEXTCLOUD_TALK,
             host="https://nextcloud.example.com",
             conversationToken="test-token",
             botSecret="test-secret",
         )
-        print(f"  ✓ Nextcloud Talk notification created: id={r['id']}")
-        created["notifications"].append(r["id"])
 
-        # ═══════════════════════════════════════════════════════════════════
-        # 7. Status Page with v2 analytics
-        # ═══════════════════════════════════════════════════════════════════
         print()
-        print("─── Creating status page with v2 analytics ───")
-
+        print("Status page with v2 analytics")
         slug = "test-v2-analytics"
         api.add_status_page(slug, f"{PREFIX}Status Page v2")
+        created["status_pages"].append(slug)
+        save_ids()
         api.save_status_page(
             slug=slug,
             title=f"{PREFIX}Status Page v2",
@@ -230,38 +365,54 @@ def main():
             showOnlyLastHeartbeat=True,
             rssTitle="Test RSS Feed",
         )
-        sp = api.get_status_page(slug)
-        print(f"  ✓ Status page created: slug={slug}")
-        created["status_pages"].append(slug)
-
-        # ═══════════════════════════════════════════════════════════════════
-        # Summary
-        # ═══════════════════════════════════════════════════════════════════
-        print()
-        print("═══════════════════════════════════════════════════")
-        print("  ALL TESTS PASSED — Resources created successfully")
-        print("═══════════════════════════════════════════════════")
-        print()
-        print("Created resources:")
-        print(f"  Monitors:      {created['monitors']}")
-        print(f"  Notifications: {created['notifications']}")
-        print(f"  Status Pages:  {created['status_pages']}")
-        print()
-        print("→ Go inspect them in the Uptime Kuma UI at:")
-        print(f"  {URL}")
-        print()
-        print("→ When done, run cleanup:")
-        print("  .venv\\Scripts\\python tests/live_test_cleanup.py")
-
-        # Save created IDs for cleanup script
-        with open("tests/.live_test_ids.json", "w") as f:
-            json.dump(created, f, indent=2)
-        print()
-        print(f"  (IDs saved to tests/.live_test_ids.json)")
+        got = api.get_status_page(slug)
+        check(
+            f"status page v2 analytics (slug={slug})",
+            {"analyticsType": "plausible",
+             "analyticsId": "test-domain.example.com",
+             "analyticsScriptUrl": "https://plausible.io/js/script.js",
+             "showOnlyLastHeartbeat": True,
+             "rssTitle": "Test RSS Feed"},
+            got,
+        )
+        # v2 replaced googleAnalyticsId with the analytics* fields, so its
+        # continued absence is part of the contract.
+        check_absent(
+            "status page omits v1 googleAnalyticsId on v2",
+            "googleAnalyticsId",
+            got,
+        )
 
     finally:
         api.disconnect()
 
+    passed = sum(1 for _, ok, _ in results if ok)
+    failed = len(results) - passed
+
+    print()
+    print("=" * 60)
+    print(f"  {passed} passed, {failed} failed, {len(results)} checks total")
+    print("=" * 60)
+
+    if failed:
+        print()
+        print("Failed checks:")
+        for label, ok, detail in results:
+            if not ok:
+                print(f"  {label}")
+                print(f"    {detail}")
+
+    print()
+    print("Created resources:")
+    print(f"  monitors:      {created['monitors']}")
+    print(f"  notifications: {created['notifications']}")
+    print(f"  status pages:  {created['status_pages']}")
+    print()
+    print(f"Inspect them at {os.environ['UPTIME_KUMA_URL']}")
+    print("Then clean up:  .venv\\Scripts\\python tests/live_test_cleanup.py")
+
+    return 1 if failed else 0
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
Turns the live integration test from a smoke test into something that actually verifies behaviour, and adds a backup step to run before it.

**Validated end-to-end against a real Uptime Kuma 2.4.0 instance: 13/13 round-trip checks passed, cleanup then removed exactly the 12 test resources and left 21 pre-existing monitors untouched (confirmed by diffing against the pre-test snapshot).**

## Why

The create script asserted almost nothing. Its one assertion was:

`assert mon.get('ipFamily') is not None or True`

`X or True` is unconditionally true, so it could never fail. The status page was fetched into a variable that was never inspected. The script proved only that the server did not reject the requests, leaving real verification to manual inspection in the UI.

Round-trip comparison is where the interesting bugs are. A server that silently drops or renames a field is indistinguishable from success unless you read the resource back and compare.

## live_test_create.py

- Read every created resource back and compare returned fields against sent ones, distinguishing **ABSENT** (field dropped, or the library sends the wrong key) from **MISMATCH** (value differs, usually a type or format problem)
- Tolerate the type coercion Uptime Kuma applies through its database (bool as 0/1, numbers as strings, lists as JSON strings) while staying strict about genuine differences
- Assert `googleAnalyticsId` is *absent* on v2, since the `analytics*` fields replaced it
- Collect all failures and exit non-zero, rather than aborting on the first
- Write the cleanup ID file after each creation, not only at the end, so a mid-run crash still leaves a cleanup trail
- Preflight refuses to run against a server below 2.0, and refuses to run when default notifications exist, since every monitor here is intentionally unreachable and would fire a DOWN alert. Override with `--allow-default-notifications`.

## live_test_cleanup.py

- **Fix `UnicodeEncodeError` that crashed the script on Windows.** It printed U+2713 and U+2717, which cp1252 cannot encode, so it died on the first status line before deleting anything. Output is now ASCII only.
- Add `--dry-run` to preview exactly what matches before deleting
- Report resources left untouched, making the blast radius visible
- Continue past individual delete failures and report them, instead of aborting and leaving partial state
- Retain the IDs file when any deletion failed, so a retry can still use it

## live_test_backup.py (new)

Uptime Kuma exposes no download-backup endpoint, only `upload_backup` for importing its own legacy format, so there is no API-level database backup. This exports the full configuration to a timestamped JSON snapshot to run before a live test.

- Each section fetched independently so one unsupported endpoint cannot abort the export; per-section errors are recorded in the file and exit non-zero
- Documents plainly that this is a **reference snapshot**, not restorable via `upload_backup`, and excludes heartbeat history
- Prints the `docker cp` / `cp` commands for a genuine database snapshot

`tests/.backups/` is gitignored: the output contains notification API keys, basic-auth passwords and proxy credentials in plain text.

## How the verification itself was verified

13/13 passing first time is worth being suspicious of, so I ran a negative control against real server data: a correct expectation passed, a wrong OID failed as MISMATCH, a made-up field name failed as ABSENT, and a wrong port failed. The harness detects problems rather than rubber-stamping. The comparison logic was also exercised against 22 coercion and difference cases plus the pass/fail reporting paths.

## Notes

- No library code is touched. Test scripts and `.gitignore` only, so CI behaviour is unchanged and these scripts are not run by CI (they need a live server).
- Observed while testing: occasional socket.io login timeouts on repeat connections, likely Uptime Kuma login rate limiting. Retry succeeds. Worth knowing when scripting against an instance.
