### PR TITLE
docs: prepare the 2.3.0 release and record branch protection

### DIFF
--- a/.kiro/steering/git-and-releasing.md
+++ b/.kiro/steering/git-and-releasing.md
@@ -44,10 +44,61 @@ history is Conventional-Commit-clean.
 - Merge via PR (`--merge`) and delete the branch after.
 - **Never force-push** or rewrite published history. Prefer new commits over
   amending anything already pushed.
+- **Rewriting *unpushed* history is safe** and needs no force-push — but verify
+  that before rewriting, don't assume it. `git merge-base --is-ancestor
+  origin/<branch> HEAD` must exit 0: that proves the remote tip is still an
+  ancestor of yours, so a plain `git push` fast-forwards. Take a
+  `backup/<name>` ref first so the pre-rewrite commits stay reachable. Note the
+  catch for content scrubs: while that backup ref exists, `git log --all
+  -S"<string>"` still finds the old content, so the scrub is not complete until
+  the backup is deleted.
 - The `upstream` remote that used to make `gh` target lucasheld's repo was
   removed (2026-07-30), but keep passing `-R` anyway:
   `-R pbarone/uptime-kuma-api2` for ours, `-R lucasheld/uptime-kuma-api` for
   upstream.
+
+**Merge method: merge commits (`--merge`).** Squash and rebase are not used. The
+per-commit reasoning on a branch is worth keeping — the bodies explain why each
+step was taken — and `git log --first-parent main` still gives the clean
+release-level view when that's what you want. Honest caveat: the `protect-main`
+ruleset currently still *permits* squash and rebase, so this is convention, not
+enforcement. Narrowing **Allowed merge methods** to merge-only is a recommended
+follow-up, so the setting matches the documented policy.
+
+## Branch protection — the conventions are enforced now
+
+Two rulesets exist, both with **empty bypass lists** and
+`current_user_can_bypass: never`. There is no admin override: a direct push to
+`main` is *rejected*, not merely against convention.
+
+`protect-main` targets the default branch with `pull_request` (0 required
+approvals), `required_status_checks`, `deletion` and `non_fast_forward`.
+`protect-release-tags` is covered under "Publishing is irreversible" below.
+
+If CI is ever broken for reasons unrelated to the change you need to land, the
+escape hatch is to set the ruleset's **Enforcement** to Disabled temporarily and
+re-enable it right after — a deliberate, logged act. Do **not** add a bypass
+actor instead: with a single maintainer, that permanently disables the
+protection rather than suspending it once.
+
+### The drift coupling to watch
+
+`protect-main` requires six status checks **by literal name**: `full (3.8)`,
+`full (3.9)`, `full (3.10)`, `full (3.11)`, `full (3.12)`, `full (3.13)`. These
+must stay in sync with the Python matrix in `.github/workflows/test.yml`. Change
+one without the other and the failure is silent, in one of two directions:
+
+- A required check that never reports (version dropped from the matrix, still
+  required) blocks **every** merge, forever, with nothing to fix in the code.
+- A new matrix version that isn't in the required list silently stops gating —
+  merges pass while that version is untested.
+
+**Never add `quick (3.11)` as a required check.** It is deliberately skipped on
+`pull_request` events, so requiring it would deadlock every merge.
+
+This is the same class of drift as the explicit unit-test file list, which has
+bitten this project repeatedly: two places encode the same fact, and only one
+gets updated. Treat a matrix edit as a two-file change.
 
 ## CHANGELOG discipline
 
@@ -86,6 +137,19 @@ Bump `uptime_kuma_api/__version__.py` — the single source of truth:
 A PyPI version number is burned permanently and a filename can never be
 re-uploaded. Get explicit confirmation before pushing a release tag, and never
 tag a red `main`.
+
+**The tag is irreversible too, and earlier than PyPI.** The
+`protect-release-tags` ruleset targets `refs/tags/v*` with `update`, `deletion`
+and `non_fast_forward` rules and an empty bypass list. So a release tag cannot be
+moved or deleted from the moment it lands — before the PyPI upload, not after
+it. `git tag -d` plus a re-push is no longer a fix for a mistagged commit; the
+only recovery is burning the next patch version on a corrected tag.
+
+That moves the point of no return earlier and raises the stakes on the pre-tag
+checks. Before `git push origin vX.Y.Z`, confirm both:
+
+- `__version__.py` matches the tag you are about to push, exactly.
+- `main` is green — the full matrix, on the commit you are tagging.
 
 ## Secrets
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,10 @@ The type guides the version bump (fix → patch, feat → minor, breaking → ma
 3. Fill in the PR checklist (tests, changelog, backward-compat, docs).
 4. A maintainer merges after review.
 
+`main` is branch-protected, so steps 1 and 2 are enforced rather than merely
+asked for: a direct push is rejected, a pull request is required, and the full
+Python 3.8–3.13 matrix must report green before the merge button unlocks.
+
 ## A note on AI-agent steering files
 
 This repo commits AI-agent guidance under `.kiro/steering/`. Because those

--- a/README.md
+++ b/README.md
@@ -28,17 +28,15 @@ Python version 3.8+ is required. Tested on 3.8 through 3.13.
 
 Supported Uptime Kuma versions:
 
-| Uptime Kuma    | uptime-kuma-api2   |
-|----------------|--------------------|
-| 1.21.3 - 2.5.0 | 2.3.0 (unreleased) |
+| Uptime Kuma    | uptime-kuma-api2 |
+|----------------|------------------|
+| 1.21.3 - 2.5.0 | 2.3.0            |
 
 One install covers both majors — there is no separate v1 line to pin to. Server-version-specific behaviour is gated at runtime, so the same package works against a 1.x and a 2.x server.
 
 The range above is what the project tests against. The Docker matrix in `run_tests.sh` exercises the version gate boundaries across it — 1.21.3, 1.22.x, 1.23.x, 2.0.0, 2.1.0 and 2.5.0 — and this tree was additionally live-verified end to end against 1.23.2 and 2.5.0.
 
 Uptime Kuma older than 1.21.3 is **not** supported: that support was dropped in uptime-kuma-api 1.0.0. If you run one of those servers, use 0.13.0.
-
-2.3.0 is **not yet published on PyPI** — the latest release you can install is 2.2.1, and the row above records what the current `main` supports.
 
 Earlier release lines, kept as a record of what each published version was documented to support:
 


### PR DESCRIPTION
## What and why

Docs-only. Two things, both tied to the 2.3.0 release landing on `main`.

**README — drop the pre-release markers.** The supported-versions table cell
becomes plain `2.3.0`, and the "2.3.0 is **not yet published on PyPI**"
paragraph is deleted. It is *not* replaced with a claim that 2.3.0 *is*
published: this PR merges before the `v2.3.0` tag is pushed, so a positive
publication claim would be briefly false. Removing the claim leaves the table
saying only "this library version supports these servers" — true either side of
the tag, and no follow-up edit needed after tagging. The historical table
(2.2.1 / 1.2.1 / 0.13.0 rows) is untouched; it records published lines and stays
correct.

**Steering + CONTRIBUTING — record that the conventions are now enforced.**
`.kiro/steering/git-and-releasing.md` gains:

- **Tag immutability.** `protect-release-tags` covers `refs/tags/v*` with
  `update`, `deletion` and `non_fast_forward` and an empty bypass list, so a
  release tag cannot be moved or deleted from the moment it lands — before the
  PyPI upload, not after. `git tag -d` is no longer a fix for a mistag; recovery
  costs the next patch version. Adds the explicit pre-tag checks that follow
  from that: `__version__` matches the tag, `main` green on the tagged commit.
- **Branch protection is real, not convention.** `protect-main` requires a PR
  (0 approvals), status checks, and blocks deletion and non-fast-forward. Both
  rulesets have empty bypass lists and `current_user_can_bypass: never`, so a
  direct push to `main` is rejected outright. The escape hatch for unrelated CI
  breakage is disabling Enforcement temporarily — not adding a bypass actor,
  which with one maintainer would remove the protection entirely.
- **The drift coupling.** Six required checks by literal name (`full (3.8)`
  through `full (3.13)`) that must track `test.yml`'s matrix, with both silent
  failure modes spelled out, plus the specific trap: never require
  `quick (3.11)`, which is skipped on `pull_request` and would deadlock every
  merge. Same class of drift as the unit-test file list.
- **Rewriting unpushed history safely,** beside the existing never-force-push
  rule (which stays as written): prove `git merge-base --is-ancestor
  origin/<branch> HEAD` exits 0, take a `backup/<name>` ref first, and note that
  the backup keeps scrubbed content findable via `git log --all -S` until it is
  deleted.
- **Merge method:** merge commits (`--merge`), preserving per-commit reasoning
  while `git log --first-parent main` gives the release-level view.

`CONTRIBUTING.md` gets one sentence in "Pull requests" so external contributors
know a PR is required and the full 3.8–3.13 matrix gates it.

## Checklist

- [x] Title follows Conventional Commits (`fix:` / `feat:` / `docs:` / `test:` / `ci:` / `refactor:` / `chore:`; `!` for breaking)
- [x] Tests pass: the v2 unit suite runs clean (see CONTRIBUTING)
- [ ] Bug fixes include a regression test **proven to fail against the unfixed code** — n/a, no code change
- [x] Backward compatibility with Uptime Kuma v1.x is preserved (version-gated where needed) — n/a, no code change
- [x] Public API changes are additive; new public classes are exported in `__init__.py` **and** added to `docs/api.rst` — n/a, no API change
- [ ] `CHANGELOG.md` updated for any user-facing change — n/a, no user-facing behaviour change; the README edit is release bookkeeping for the already-changelogged 2.3.0
- [x] No secrets, tokens, or real credentials in the diff

## Notes for the reviewer

Docs-only: no package code, tests, or workflows are touched. The nine-file v2
unit suite was run anyway and is green (213 passed, 1162 subtests).

**This should land before the `v2.3.0` tag is pushed.** It documents the new tag
immutability, which is exactly the constraint that applies at the moment of
tagging — the guidance is worth having in the tree before the first tag it
governs, and the README wording was chosen so nothing needs re-editing
afterwards.

Suggested follow-up, not done here: narrow the repository's **Allowed merge
methods** to merge-only. The steering now documents merge commits as the chosen
method, but the setting still permits squash and rebase, so the policy is
convention rather than enforcement until that is changed.
