### PR TITLE
chore: bump Jinja2 to 3.1.6 and document all branch prefixes

### DIFF
--- a/.kiro/steering/git-and-releasing.md
+++ b/.kiro/steering/git-and-releasing.md
@@ -40,7 +40,13 @@ history is Conventional-Commit-clean.
 
 - **Never commit directly to `main`.** Work on a branch, open a PR, let CI run
   the full matrix, then merge.
-- Branch names: `fix/...`, `feat/...`, `docs/...`, `ci/...`.
+- Branch names: `<type>/<short-description>`, where `<type>` is the
+  Conventional Commit type of the change's dominant purpose — so any type from
+  the **Types** list above is valid (`feat`, `fix`, `docs`, `test`, `ci`,
+  `refactor`, `chore`), e.g. `chore/bump-jinja2-3-1-6`. Stated as a rule rather
+  than a fixed list of prefixes on purpose: a second enumerated list here would
+  duplicate the Types list and drift from it, which is the same failure mode as
+  the status-check coupling described below.
 - Merge via PR (`--merge`) and delete the branch after.
 - **Never force-push** or rewrite published history. Prefer new commits over
   amending anything already pushed.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 Sphinx==7.4.7
 pyotp==2.9.0
-Jinja2==3.1.4
+Jinja2==3.1.6
 BeautifulSoup4==4.12.3
 python-dotenv==1.2.2


### PR DESCRIPTION
## What and why

Two small maintenance changes. Neither ships to PyPI users.

**1. `Jinja2==3.1.4` → `3.1.6` in `dev-requirements.txt`** (Closes #9)

Clears three open Dependabot alerts, all `scope: development` against
`dev-requirements.txt`:

| Advisory | Vulnerable range | First patched |
|---|---|---|
| GHSA-q2x7-8rv6-6q7h | `<= 3.1.4` | 3.1.5 |
| GHSA-gmj6-6f8f-6699 | `>= 3.0.0, <= 3.1.4` | 3.1.5 |
| GHSA-cpwx-vrp4-4pq7 | `<= 3.1.5` | **3.1.6** |

3.1.5 would clear two of the three and silently leave the last one open while
looking finished, so this goes straight to 3.1.6. Sphinx 7.4.7 declares
`Jinja2>=3.1`, so nothing else has to move, and 3.1.6 adds no new transitive
requirements (`MarkupSafe>=2.0` was already satisfied).

Not a user-facing vulnerability: `dev-requirements.txt` is not part of the
published distribution, so no released artifact is affected. The value is alert
hygiene — three stale alerts sitting open make a future serious one easy to
miss.

**2. Branch-prefix convention stated as a rule** (`.kiro/steering/git-and-releasing.md`)

The branch-name line listed only `fix/`, `feat/`, `docs/` and `ci/`, omitting
`test/`, `refactor/` and `chore/` even though all seven are sanctioned
Conventional Commit types in the **Types** list a few lines above — and even
though this repo's own PR template already lists all seven. That made the
`chore/` branch this PR is on undocumented.

Rather than appending the three missing prefixes, the fixed list is replaced by
the rule *prefix = the Conventional Commit type of the change's dominant
purpose*. A second enumerated list would duplicate the Types list and drift
from it, which is the same failure mode this file already warns about for the
six required status-check names, and which has bitten this project once already
via the nine-file CI test list.

## Checklist

- [x] Title follows Conventional Commits (`fix:` / `feat:` / `docs:` / `test:` / `ci:` / `refactor:` / `chore:`; `!` for breaking)
- [x] Tests pass: the v2 unit suite runs clean (see CONTRIBUTING)
- [x] Bug fixes include a regression test **proven to fail against the unfixed code** — n/a, no code change
- [x] Backward compatibility with Uptime Kuma v1.x is preserved (version-gated where needed) — n/a, no library code touched
- [x] Public API changes are additive; new public classes are exported in `__init__.py` **and** added to `docs/api.rst` — n/a, no public API change
- [x] `CHANGELOG.md` updated for any user-facing change — n/a, deliberately: neither change is user-facing
- [x] No secrets, tokens, or real credentials in the diff

## Notes for the reviewer

No live server needed. Verified locally on 3.1.6:

- `pip install -r dev-requirements.txt` resolves cleanly.
- `scripts/utils.py`'s Jinja2 environment still loads `monitor_type.py.j2` —
  worth checking because Sphinx is not the only consumer; the code-generation
  scripts import `jinja2` directly.
- `cd docs && make html` → `build succeeded`.
- Nine-file unit suite: **213 passed, 1162 subtests**, matching the documented
  baseline.

`CHANGELOG.md` is intentionally untouched. Per the CHANGELOG discipline in
steering, entries are for *user-facing* changes; a dev-only pin and a steering
doc are neither.

Follow-up, not in this PR: #10 (declare `requests` as a runtime dependency) is
the natural next one. It is deliberately sequenced after this so that the
Dependabot alert list is clean before #10 gives Dependabot visibility into
`requests`/`urllib3`. Unlike this PR, #10 only reaches users on a release.
