### PR TITLE
docs: record the gh/git convention for GitHub lookups in steering

### DIFF
--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -50,6 +50,41 @@ pip install -r dev-requirements.txt
 cd docs && make html   # docs/make.bat on Windows
 ```
 
+## GitHub and external lookups
+
+GitHub is interrogated with `gh` and `git`, **not** web search. Three
+repositories are in play, and `-R` is always passed explicitly rather than
+relying on the working directory:
+
+| Repository | `-R` value | What it answers |
+|---|---|---|
+| This project | `pbarone/uptime-kuma-api2` | our issues, PRs, releases, CI runs |
+| The original library | `lucasheld/uptime-kuma-api` | upstream triage, inherited issues and PRs |
+| The Uptime Kuma server | `louislam/uptime-kuma` | server behavior — when a field, monitor type or event appeared |
+
+For any question about **server** behavior — which version introduced a field, a
+monitor type, an event — the authoritative source is Uptime Kuma's own source
+and tags (`git log -S`, `git tag --contains`, `gh release view`), never a blog
+post or secondary summary. A wrong answer here becomes a wrong version gate, and
+a wrong version gate breaks v1.x.
+
+Web search is for things genuinely outside these repositories: security advisory
+details, PEP text, third-party library documentation. It is not how to answer a
+question a repository can answer.
+
+## Disposable test containers
+
+This workstation has no Docker. Disposable Uptime Kuma containers run on a
+separate host reached over SSH; its address and SSH user are recorded in the
+**gitignored** root `.env` as `DOCKER-HOST` / `DOCKER-USER`. Read them from
+there. They contain hyphens, so they are recorded values rather than consumable
+shell variables.
+
+**Never write that address, the SSH user, or any credential into a tracked
+file.** It has been scrubbed from this repo's history once already and is
+currently absent from it. Committed prose uses the `<docker-host>` and `<user>`
+placeholders the existing specs use.
+
 ## Critical safety rule
 
 **Never run the full `pytest tests/` against a real Uptime Kuma instance.** The


### PR DESCRIPTION
## What and why

An agent asked to establish which Uptime Kuma version introduced a given monitor
type reached for web search instead of `gh` / `git`. Nothing it could see told it
otherwise.

The root cause is an inclusion-mode gap, not a missing convention.
`git-and-releasing.md` already documents the `gh` habit, including the `-R`
convention for our repo versus upstream — but it is `inclusion: manual`, so it
never enters an agent's context unless someone explicitly references
`#git-and-releasing`. `tech.md` is always-included, so the convention now lives
there.

Two sections added:

**`## GitHub and external lookups`** — GitHub is interrogated with `gh` and
`git`, not web search. Names all three repositories in play and their `-R`
values: this project, the original library (`lucasheld/uptime-kuma-api`), and the
Uptime Kuma server itself (`louislam/uptime-kuma`) — the third being the one that
was actually needed and the one no steering file had ever mentioned.

It also states the consequence, which is the part that makes this more than a
style preference: questions about server behaviour are answered from Uptime
Kuma's own source and tags (`git log -S`, `git tag --contains`,
`gh release view`), because a wrong answer there becomes a wrong version gate,
and a wrong version gate breaks v1.x.

**`## Disposable test containers`** — this workstation has no Docker, so
containers run on a separate host over SSH. The address and SSH user are recorded
in the gitignored root `.env` as `DOCKER-HOST` / `DOCKER-USER`, and the section is
a **pointer only**: it explicitly forbids writing the address, the SSH user or
any credential into a tracked file. That address was scrubbed from this repo's
history once already and is currently absent from it; committed prose uses the
`<docker-host>` / `<user>` placeholders the existing specs already use.

## Checklist

- [x] Title follows Conventional Commits (`fix:` / `feat:` / `docs:` / `test:` / `ci:` / `refactor:` / `chore:`; `!` for breaking)
- [x] Tests pass: the v2 unit suite runs clean (see CONTRIBUTING)
- [x] Bug fixes include a regression test **proven to fail against the unfixed code** — n/a, no code change
- [x] Backward compatibility with Uptime Kuma v1.x is preserved (version-gated where needed) — n/a, no library code touched
- [x] Public API changes are additive; new public classes are exported in `__init__.py` **and** added to `docs/api.rst` — n/a, no public API change
- [x] `CHANGELOG.md` updated for any user-facing change — n/a, steering guides contributors and agents, not library users
- [x] No secrets, tokens, or real credentials in the diff — **explicitly verified**: the diff was grepped for the host address and SSH user before committing; placeholders only

## Notes for the reviewer

`CONTRIBUTING.md` states that a PR editing `.kiro/steering/` is reviewed with the
same care as code rather than as a docs tweak, which is why this is its own PR
instead of riding along with the `tests/.env.example` work that prompted the same
investigation.

### Two related findings, deliberately not fixed here

Both are separate decisions and would muddy this diff.

1. **`testing.md` is `inclusion: fileMatch` on `tests/**/*.py`.** So "never run
   bare `pytest tests/`" — the most destructive mistake available in this repo —
   sits in a file that does not load until a test file is already in context.
   `AGENTS.md` restates the rule and does auto-load, so the rule is not
   unguarded, but the protection currently comes from the mirror rather than from
   the source. Worth deciding whether to promote `testing.md` to
   always-included.

2. **`CONTRIBUTING.md` still lists three branch prefixes** (`fix/`, `feat/`,
   `docs/`), which is now inconsistent with the rule merged in #16 that any
   Conventional Commit type is valid. That is a third copy of a list #16 set out
   to de-duplicate and missed. It is being corrected in the follow-up
   `tests/.env.example` PR, which touches the same file.
