### PR TITLE
docs: add tests/.env.example and document live verification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,27 @@ pytest tests/test_monitor_types_v2.py tests/test_monitor_params_v2.py \
 > keys) on the target during setup. They are meant for a disposable instance
 > (e.g. a throwaway Docker container).
 
+### Live verification (optional, maintainer-scoped)
+
+**A contribution does not need this.** The unit suite above requires no
+configuration and is the whole of what CI runs.
+
+Separately, `tests/live_test_*.py` are manual scripts that check round-trip
+behaviour against a real Uptime Kuma instance. They are `live_test_`-prefixed so
+pytest never collects them. They read their configuration from `tests/.env`:
+
+```
+cp tests/.env.example tests/.env    # then fill in your own values
+```
+
+`tests/.env.example` lists every key, which script consumes it, and what each is
+for. `tests/.env` is gitignored and must stay that way.
+
+These scripts **create and delete data** on whatever you point them at —
+`live_test_cleanup.py` deletes monitors, notifications and status pages — so use
+a disposable instance you own, and always run `live_test_cleanup.py --dry-run`
+before the real thing.
+
 ## What we look for in a change
 
 - **Reproduce before fixing.** Issue titles here often misdescribe the real
@@ -67,7 +88,10 @@ The type guides the version bump (fix → patch, feat → minor, breaking → ma
 
 ## Pull requests
 
-1. Work on a branch (`fix/...`, `feat/...`, `docs/...`), never commit to `main`.
+1. Work on a branch named `<type>/<short-description>`, where `<type>` is the
+   Conventional Commit type of the change's main purpose (so any of the types
+   listed above — e.g. `fix/...`, `docs/...`, `chore/...`). Never commit to
+   `main`.
 2. Open a PR against `main`; CI runs the full Python 3.8–3.13 matrix.
 3. Fill in the PR checklist (tests, changelog, backward-compat, docs).
 4. A maintainer merges after review.

--- a/tests/.env.example
+++ b/tests/.env.example
@@ -1,0 +1,46 @@
+# Configuration for the manual live_test_* scripts in this directory.
+#
+# Copy to tests/.env and fill in your own values. tests/.env is gitignored and
+# must stay that way -- it holds real credentials.
+#
+#     cp tests/.env.example tests/.env
+#
+# NONE of this is needed to run the unit suite, which is what CI runs and what
+# a contribution normally requires. These scripts are optional, manual, and
+# maintainer-scoped. See "Live verification" in CONTRIBUTING.md.
+#
+# WARNING: several of these scripts CREATE AND DELETE data on the target.
+# live_test_cleanup.py deletes monitors, notifications and status pages.
+# Point them only at a disposable instance you own.
+#
+# Never put a real host address or credential in this file -- it is tracked.
+
+
+# --- Uptime Kuma 2.x target -------------------------------------------------
+# Used by: live_test_backup.py, live_test_create.py, live_test_cleanup.py,
+#          live_test_delete_id.py, live_test_ssl_verify.py
+UPTIME_KUMA_URL=http://localhost:3001/
+UPTIME_KUMA_USERNAME=admin
+UPTIME_KUMA_PASSWORD=change-me
+
+
+# --- Endpoint with an untrusted TLS certificate -----------------------------
+# Used by: live_test_ssl_verify.py (with the username/password above).
+# Must be an endpoint whose certificate is genuinely NOT publicly trusted --
+# the script aborts if the certificate turns out to be valid, because that
+# would make the test vacuous.
+UPTIME_KUMA_SELFSIGNED_URL=https://localhost:3002/
+
+
+# --- Uptime Kuma 1.x target (separate keys on purpose) ----------------------
+# Used by: live_test_conditions_v1.py, which verifies v1.x backward
+# compatibility against a DISPOSABLE 1.23.x container:
+#
+#     docker run -d --name kuma-v1 -p 3023:3001 louislam/uptime-kuma:1.23.2
+#
+# These keys are deliberately distinct from the 2.x ones above so the v1 script
+# cannot be mistargeted at your 2.x instance. The script refuses to run if the
+# URL is unset and aborts unless the server reports 1.23.
+UPTIME_KUMA_V1_URL=http://localhost:3023/
+UPTIME_KUMA_V1_USERNAME=admin
+UPTIME_KUMA_V1_PASSWORD=change-me


### PR DESCRIPTION
## What and why

A contributor cloning this repo had no way to discover how the live test scripts
are configured, short of opening six files.

The seven environment keys are documented — but only inside each script's own
docstring ("Create a `tests/.env` file with:", "Add to `tests/.env`:",
"Create/extend `tests/.env` with:"). There is no single place listing the full
set, and neither `CONTRIBUTING.md` nor `README.md` mentions `.env`, the keys, or
the live scripts at all, so nothing signalled that any of it existed.

### `tests/.env.example`

The single canonical list: all seven keys with placeholder values, grouped by
which script consumes each, in three blocks — the 2.x target, the untrusted-TLS
endpoint, and the 1.x target.

The 1.x keys are included even though they are absent from the maintainer's
current `tests/.env`; that absence is exactly the documentation gap, and #12's
verification work needs them. The comment notes why they are deliberately
distinct from the 2.x keys: it is what stops the v1 script being mistargeted at a
2.x instance.

Verified in both directions rather than by eye — 7 keys consumed by the scripts,
7 declared in the template, nothing missing and nothing spurious.

`tests/.env.example` is not caught by `.gitignore` (the entries are `.env` and
`tests/.env`, both matching that exact filename), so it commits with no ignore
change.

### `CONTRIBUTING.md` — "Live verification (optional, maintainer-scoped)"

Points at the template rather than re-listing the keys, and leads with the thing
that matters most to a first-time contributor: **you do not need any of this.**
The unit suite requires no configuration and is the whole of what CI runs.

The framing is deliberate. These scripts create and delete data —
`live_test_cleanup.py` deletes monitors, notifications and status pages — so the
section says so, points at `--dry-run`, and frames live verification as optional
and maintainer-scoped rather than as an expected part of contributing.

### Also: a branch-prefix correction

The line under "Pull requests" still read:

> Work on a branch (`fix/...`, `feat/...`, `docs/...`), never commit to `main`.

That is inconsistent with the rule merged in #16, which replaced the fixed prefix
list in steering with "the Conventional Commit type of the change's dominant
purpose". #16's stated rationale was that a second enumerated list would
duplicate the Types list and drift from it — and it missed this third copy in
`CONTRIBUTING.md`. Now states the rule instead of a partial list.

## Checklist

- [x] Title follows Conventional Commits (`fix:` / `feat:` / `docs:` / `test:` / `ci:` / `refactor:` / `chore:`; `!` for breaking)
- [x] Tests pass: the v2 unit suite runs clean (see CONTRIBUTING)
- [x] Bug fixes include a regression test **proven to fail against the unfixed code** — n/a, no code change
- [x] Backward compatibility with Uptime Kuma v1.x is preserved (version-gated where needed) — n/a, no library code touched
- [x] Public API changes are additive; new public classes are exported in `__init__.py` **and** added to `docs/api.rst` — n/a, no public API change
- [x] `CHANGELOG.md` updated for any user-facing change — n/a, nothing here is user-facing
- [x] No secrets, tokens, or real credentials in the diff — **explicitly verified**: template holds `localhost` placeholders only, and the diff was grepped for the real host address and SSH user before committing

## Notes for the reviewer

### On the duplication this deliberately accepts

The template is a seventh copy of the key list, which is the pattern that has hurt
this project before — the nine-file CI list disagreeing across five places, and
`tests/test_status_page_incidents.py` sitting unexecuted in CI for a whole
release because of it.

Accepted here for one specific reason: **this duplication fails loudly.**
`live_test_backup.py` aborts with `ABORT: <KEY> is not set in tests/.env`, naming
the missing key, so a stale or incomplete template produces an immediate
self-describing error. The CI-list drift failed silently, which is what made it
expensive. Loud drift in exchange for a discovery point people actually look for
is a trade worth making.

To keep it from getting worse, `CONTRIBUTING.md` points at the template rather
than restating the keys, so there is one canonical list and not two.

### No root `.env.example`, on purpose

All six `load_dotenv` calls resolve to `tests/.env`
(`os.path.join(os.path.dirname(__file__), ".env")`), so nothing in the repo reads
the root `.env` — it holds only local `DOCKER-HOST` / `DOCKER-USER` notes, whose
hyphens mean they could not be consumed as environment variables anyway. A root
template would tell contributors to create a file no code reads, while
advertising infrastructure deliberately kept out of the repo.

### Not addressed here

`testing.md` is `inclusion: fileMatch` on `tests/**/*.py`, so "never run bare
`pytest tests/`" lives in a file that does not load until a test file is already
in context. `AGENTS.md` restates it and does auto-load, so the rule is not
unguarded — but the protection comes from the mirror rather than the source.
Raised in #18 as well; still a separate decision.
