### PR TITLE
chore: always-include two steering files and add a .temp scratch dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ tests/.backups/
 UPSTREAM_TRIAGE.md
 # Transient spec tooling state (chat session IDs, epoch timestamps); traceability lives in tasks.md
 .kiro/specs/*/tasks.meta.json
+# Scratch files: PR/issue bodies drafted for `gh --body-file`, probe scripts,
+# captured output. See "Scratch files go in .temp/" in .kiro/steering/structure.md
+.temp/

--- a/.kiro/steering/git-and-releasing.md
+++ b/.kiro/steering/git-and-releasing.md
@@ -1,11 +1,10 @@
----
-inclusion: manual
----
-
 # Git workflow and releasing
 
-Manually include this (`#git-and-releasing`) when committing, opening PRs, or
-cutting a release.
+Always included. It was previously `inclusion: manual`, which meant the release
+safety rules under "Publishing is irreversible" — the only place in the repo
+where the immutability of a `v*` tag is written down — loaded only if someone
+explicitly referenced `#git-and-releasing`. That is the least recoverable
+operation here, so it should never have depended on being asked for.
 
 ## Commit messages — Conventional Commits
 

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -15,7 +15,23 @@ docs/                       # Sphinx: conf.py, api.rst (autodoc), index.rst, ins
 scripts/                    # code-generation helpers (build_*.py); not shipped runtime
 setup.py, CHANGELOG.md, README.md, .readthedocs.yaml
 UPSTREAM_TRIAGE.md          # local-only working notes (gitignored)
+.temp/                      # scratch files (gitignored) — see below
 ```
+
+## Scratch files go in `.temp/`
+
+Anything transient written into the working tree — a PR or issue body drafted for
+`gh --body-file`, a probe script, captured command output — goes in `.temp/`,
+which is gitignored as a whole. Create it if it isn't there.
+
+Do not scatter temp files at the repo root. Nothing there is ignored by default,
+so a file left behind shows up as untracked, `gh` warns about an uncommitted
+change on every call, and it is one careless `git add` away from being committed.
+`.temp/` makes a forgotten file harmless instead of a near miss, and it keeps the
+draft openable in the editor for review, which a system temp directory would not.
+
+Being gitignored does not make `.temp/` safe for secrets: treat it like
+`tests/.backups/`, which is also ignored and still holds plaintext credentials.
 
 ## tests/ taxonomy — know which is which
 
@@ -56,5 +72,5 @@ UPSTREAM_TRIAGE.md          # local-only working notes (gitignored)
 
 ## Never commit
 
-`tests/.env`, `tests/.backups/`, `tests/.live_test_ids.json`, and
+`tests/.env`, `tests/.backups/`, `tests/.live_test_ids.json`, `.temp/`, and
 `UPSTREAM_TRIAGE.md` are gitignored and hold secrets or transient state.

--- a/.kiro/steering/testing.md
+++ b/.kiro/steering/testing.md
@@ -1,9 +1,8 @@
----
-inclusion: fileMatch
-fileMatchPattern: 'tests/**/*.py'
----
-
 # Testing standards
+
+Always included. It was previously `inclusion: fileMatch` on `tests/**/*.py`,
+which meant the ASCII-output rule below — the only place it is recorded outside a
+gitignored file — did not load until a test file happened to be in context.
 
 ## Where tests go
 


### PR DESCRIPTION
## What and why

Two loose ends from the 2.3.1 work, both about things that were quietly not
happening.

### Only three of six steering files were auto-loading

I'd assumed most of `.kiro/steering/` was always in context. It wasn't:

| File | Was | Loads cold? |
|---|---|---|
| `product.md` | always | yes |
| `structure.md` | always | yes |
| `tech.md` | always | yes |
| `coding-standards.md` | `fileMatch **/*.py` | only once a `.py` file is in context |
| `testing.md` | `fileMatch tests/**/*.py` | only once a test file is in context |
| `git-and-releasing.md` | `manual` | never, unless someone typed `#git-and-releasing` |

Most critical rules survive that because they're mirrored somewhere
always-loaded — "never bare `pytest tests/`" is in `tech.md` and `AGENTS.md`,
"v1.x is sacred" is in `product.md`, "regression test proven to fail" is in
`AGENTS.md`. I checked each one. Two weren't:

**`git-and-releasing.md` is the only place the release-tag immutability is
written down.** `protect-release-tags` blocks `update`, `deletion` and
`non_fast_forward` on `refs/tags/v*` with an empty bypass list, so a mistagged
commit can only be fixed by burning the next patch version. That's the least
recoverable operation in this repo, documented in the one file that never loaded
on its own.

This nearly bit during 2.3.1. I only knew about it because `git-and-releasing.md`
happened to be open in the editor at the start of the session, so I read it early.

**`testing.md` holds the ASCII-output rule**, which didn't load until a test file
was in context. That rule exists because a script crashed mid-run with
`UnicodeEncodeError`, it applies to any script that prints rather than only to
tests, and its only other home is the gitignored `UPSTREAM_TRIAGE.md` — so it's
absent from a clone entirely.

Both are now always-included, with a line at the top of each recording what
changed and why, so nobody reverts it as noise.

`coding-standards.md` stays on `fileMatch **/*.py`. It's genuinely scoped to
writing Python, and its non-negotiable rule is already mirrored in always-loaded
`product.md`.

### Scratch files now have a home

`.temp/` is the designated place for anything transient written into the tree — PR
and issue bodies drafted for `gh --body-file`, probe scripts, captured output —
and it's gitignored as a whole.

The root is ignored by nothing, so a forgotten scratch file shows as untracked,
makes `gh` print `Warning: 1 uncommitted change` on every call, and sits one
careless `git add` away from being committed. That happened repeatedly with
`.pr-body-tmp.md` across the 2.3.1 PRs; deleting it each time was the only thing
preventing it.

A system temp directory would also have solved it, but `.temp/` keeps the draft
openable in the editor, which turned out to matter — reviewing a PR body that way
is how the "reads like a compliance form" problem got caught earlier.

Documented in `structure.md`, including the caveat that gitignored is not the same
as safe for secrets: `tests/.backups/` is also ignored and holds plaintext
credentials.

This PR body is the first thing written to `.temp/`, so the convention is
exercised rather than just declared.

## Checklist

- [x] Title follows Conventional Commits (`fix:` / `feat:` / `docs:` / `test:` / `ci:` / `refactor:` / `chore:`; `!` for breaking)
- [x] Tests pass: 226 passed, 1185 subtests
- [x] Bug fixes include a regression test **proven to fail against the unfixed code** — n/a, no code change
- [x] Backward compatibility with Uptime Kuma v1.x is preserved (version-gated where needed) — n/a, no library code touched
- [x] Public API changes are additive; new public classes are exported in `__init__.py` **and** added to `docs/api.rst` — n/a
- [x] `CHANGELOG.md` updated for any user-facing change — n/a, nothing here is user-facing
- [x] No secrets, tokens, or real credentials in the diff

## Notes for the reviewer

Per `CONTRIBUTING.md` a steering edit is reviewed as a code change rather than a
docs tweak, so the reasoning is spelled out above rather than left to the diff.

Verified functionally, not just by reading the diff:

- All six front matters re-read after the edit: five now always-load,
  `coding-standards.md` still `fileMatch`.
- Wrote a probe file into `.temp/` and confirmed `git check-ignore` matches it and
  that it does not appear in `git status --porcelain`.
- Confirmed only the four intended files are staged.

One consequence worth naming: with five of six always-included, the
`fileMatch`/`manual` mechanism is now nearly unused here. That's the right
outcome for a six-file, ~23 KB steering set — the mechanism earns its keep on
large ones, not on this.
