### PR TITLE
docs: document the claimed-label convention for issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,29 @@ First line: `<type>: <summary>`. Types: `feat`, `fix`, `docs`, `test`, `ci`,
 `refactor`, `chore`. Breaking changes use `!` (e.g. `feat!: drop Python 3.7`).
 The type guides the version bump (fix → patch, feat → minor, breaking → major).
 
+## Claiming an issue before you start
+
+**Say on the issue that you want it, and it's yours.** A maintainer will add the
+`claimed` label. Before starting on something, check whether that label is
+already there — if it is, ask on the issue rather than opening a competing PR.
+
+The label exists because GitHub only lets you assign issues to people with write
+access to the repository, so an outside contributor who opened an issue cannot be
+assigned to it. Adding someone as a collaborator just to mark a claim would be a
+much bigger step than the claim warrants, so the label does that job instead.
+
+There is no deadline attached to a claim, and no obligation once you have made
+one. **If you get busy or it turns out to be more work than you expected, just
+say so on the issue.** That is genuinely more useful than going quiet, because it
+frees the issue up immediately. If a claimed issue does go quiet, a maintainer
+will ask on the issue whether you are still interested and say plainly what
+happens next, rather than silently taking it over.
+
+Credit does not depend on who writes the final code. `CHANGELOG.md` credits
+contributors by handle for the diagnosis as well as the fix — see the existing
+`(credit: @handle, PR #n)` entries. If a maintainer or another contributor builds
+on commits you have already pushed, that lands with a `Co-authored-by:` trailer.
+
 ## Pull requests
 
 1. Work on a branch named `<type>/<short-description>`, where `<type>` is the


### PR DESCRIPTION
docs: document the claimed-label convention for issues

A `claimed` label was created while triaging #32 and had no documentation, so it
meant nothing to anyone who had not read that thread. This states the convention:
say on an issue that you want it, a maintainer labels it `claimed`, and check for
the label before starting so two people do not build the same thing.

Records why it is a label rather than an assignee, which is the part that is not
obvious and that I got wrong first: GitHub only permits assigning issues to users
with write access to the repository, so an outside contributor who opened an issue
cannot be assigned to it. Adding someone as a collaborator purely to mark a claim
is a far bigger step than the claim warrants.

Also writes down the two things that make a claim safe to make. There is no
deadline and no obligation, and saying so on the issue is more useful than going
quiet because it frees the issue immediately. If a claim does go quiet, a
maintainer asks on the issue before taking it over rather than doing it silently.
The failure mode worth designing against is not somebody being slow, it is
somebody disappearing because they feel bad about being slow.

Credit is stated as independent of who writes the final code, matching the
existing (credit: @handle, PR #n) entries in CHANGELOG.md, with a Co-authored-by
trailer when someone builds on pushed commits.

Docs only.
